### PR TITLE
[CHAT-988] Fix url logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ class Fetcher {
     _sanitizeUrl(url) {
         const parsedUrl = new URL(url);
 
-        return `${parsedUrl.protocol}${parsedUrl.hostname}${parsedUrl.pathname}`;
+        return `${parsedUrl.protocol}//${parsedUrl.hostname}${parsedUrl.pathname}`;
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-client-with-prom-metrics-tracking",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "",
   "main": "index.js",
   "keywords": [],


### PR DESCRIPTION
Add `//` to URLs so that they look correctly in logs
(e.g.`http://somehost` instead of `http:somehost`)