### PR TITLE
[CHAT-988] Fix faining integration test

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ class Fetcher {
     _sanitizeUrl(url) {
         const parsedUrl = new URL(url);
 
-        return `${parsedUrl.protocol}//${parsedUrl.hostname}${parsedUrl.pathname}`;
+        return `${parsedUrl.protocol}//${parsedUrl.host}${parsedUrl.pathname}`;
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "http-client-with-prom-metrics-tracking",
-  "version": "0.2.0",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1002,7 +1002,9 @@
       "dev": true
     },
     "nchat-dev-common": {
-      "version": "file:../nchat-dev-common",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/nchat-dev-common/-/nchat-dev-common-0.2.0.tgz",
+      "integrity": "sha512-Bxn2f1UPJlAB8/SifOfglqx/73suMXNMpMcTye/SGqyzZSmQqQPb+xPB6IFVHfvcxkbkf1wvJcuiwqVvM1qrpQ==",
       "dev": true
     },
     "negotiator": {


### PR DESCRIPTION
```
Fetcher fetcherFactory returned fetcher should issue error message and throw.
  Message:
    Expected 'Failed request for http://localhost/error with "request to http://localhost:3333/error failed, reason: socket hang up" after 0 seconds' to equal 'Failed request for http://localhost:3333/error with "request to http://localhost:3333/error failed, reason: socket hang up" after 0 seconds'.
```
I discovered this failure by running the tests just before publishing...