### PR TITLE
[CHAT-1354] Fix Headers typings

### DIFF
--- a/declarations/http-client-with-prom-metrics-tracking.d.ts
+++ b/declarations/http-client-with-prom-metrics-tracking.d.ts
@@ -1,3 +1,4 @@
+import { Headers } from "node-fetch"
 import { ILogger } from "nchat-dev-common"
 
 interface IFetcherClient {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "http-client-with-prom-metrics-tracking",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-client-with-prom-metrics-tracking",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "",
   "main": "index.js",
   "keywords": [],


### PR DESCRIPTION
The TypeScript built-in `Header` type was used instead of the one from `node-fetch`.